### PR TITLE
feat: Implement new filter calibration and baseline impedance tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.pio/

--- a/TODO.md
+++ b/TODO.md
@@ -34,7 +34,7 @@ This list tracks potential next steps and improvements for the PAPR firmware pro
 - [ ] **Adaptive Thresholds:**
     - [ ] Implement a "learning phase" to establish baseline respiratory rate for alerts.
     - [ ] Rework breath trigger to "ramp" based on initial user breathing.
-- [ ] **Filter Lifecycle Management:**
-    - [ ] Add a `newfilter` command to run calibration and save the baseline impedance to EEPROM.
+- [x] **Filter Lifecycle Management:**
+    - [x] Add a `newfilter` command to run calibration and save the baseline impedance to EEPROM.
 - [ ] **UI Enhancements:**
     - [ ] Use the rotary encoder on the home screen to adjust a real-time compensation value.

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,5 +1,5 @@
 [env:ATtiny3226]
-platform = atmelavr
+platform = atmelmegaavr
 board = ATtiny3226
 framework = arduino
 monitor_speed = 115200

--- a/src/eeprom_config.cpp
+++ b/src/eeprom_config.cpp
@@ -13,6 +13,7 @@ void loadConfig() {
     Kp = cfg.Kp;
     Ki = cfg.Ki;
     Kd = cfg.Kd;
+    baseline_impedance = cfg.baseline_impedance;
   } else {
     // EEPROM is not initialized or data is corrupt
     // Load default values and save them
@@ -29,6 +30,7 @@ void saveConfig() {
   cfg.Kp = Kp;
   cfg.Ki = Ki;
   cfg.Kd = Kd;
+  cfg.baseline_impedance = baseline_impedance;
 
   EEPROM.put(0, cfg);
   Serial.println(F("Configuration saved to EEPROM."));

--- a/src/globals.h
+++ b/src/globals.h
@@ -21,6 +21,7 @@ struct Config {
   double Kp;
   double Ki;
   double Kd;
+  double baseline_impedance;
 };
 
 #include <Adafruit_SSD1306.h>
@@ -56,6 +57,7 @@ extern double peak_inhale_slope;
 extern double peak_exhale_slope;
 extern double avg_peak_inhale_slope;
 extern double avg_peak_exhale_slope;
+extern double baseline_impedance;
 #include "menu.h" // For MenuState enum
 
 extern String serialCommand;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,6 +48,7 @@ double peak_inhale_slope = 0.0;
 double peak_exhale_slope = 0.0;
 double avg_peak_inhale_slope = 2.0; // Initial default
 double avg_peak_exhale_slope = -2.0; // Initial default
+double baseline_impedance = 0.0;
 String serialCommand;
 bool apnea_alert_active = false;
 bool alerts_muted = false;

--- a/src/serial_commands.cpp
+++ b/src/serial_commands.cpp
@@ -105,6 +105,51 @@ void runCalibration() {
   Serial.println(F("Calibration finished."));
 }
 
+void runNewFilterCalibration() {
+  Serial.println(F("Entering new filter calibration mode..."));
+
+  // Turn off PID control during calibration
+  // by setting fan speed directly.
+
+  float prev_pressure = 0;
+  int prev_pwm = 0;
+
+  double total_impedance = 0;
+  int num_samples = 0;
+
+  for (int pwm = minPWM10p; pwm <= 255; pwm += 10) {
+    analogWrite(PWMPin, pwm);
+    delay(2000); // Wait 2 seconds for system to stabilize
+
+    float currentPressure = getPressure();
+
+    // Calculate impedance
+    float delta_pressure = currentPressure - prev_pressure;
+    int delta_pwm = pwm - prev_pwm;
+    float impedance = 0;
+    if (delta_pressure > 0) {
+      impedance = (float)delta_pwm / delta_pressure;
+      total_impedance += impedance;
+      num_samples++;
+    }
+
+    prev_pressure = currentPressure;
+    prev_pwm = pwm;
+  }
+
+  if (num_samples > 0) {
+    baseline_impedance = total_impedance / num_samples;
+    Serial.print(F("Calibration finished. New baseline impedance: "));
+    Serial.println(baseline_impedance);
+    saveConfig();
+  } else {
+    Serial.println(F("Calibration failed to calculate impedance."));
+  }
+
+  // Calibration finished, return to normal operation
+  analogWrite(PWMPin, 0); // Turn off fan before resuming PID
+}
+
 void checkSerialCommands() {
   while (Serial.available() > 0) {
     char c = (char)Serial.read();
@@ -119,6 +164,10 @@ void checkSerialCommands() {
       // Handle 'autotune' command
       else if (serialCommand.equalsIgnoreCase("autotune")) {
         runAutotune();
+      }
+      // Handle 'newfilter' command
+      else if (serialCommand.equalsIgnoreCase("newfilter")) {
+        runNewFilterCalibration();
       }
       // Handle 'save' command
       else if (serialCommand.equalsIgnoreCase("save")) {


### PR DESCRIPTION
This PR implements the "Filter Lifecycle Management" feature from the TODO list. It adds a new serial command `newfilter` which runs a calibration routine to measure the system's baseline impedance and saves it to the EEPROM configuration. It also includes a fix to `platformio.ini` to correctly use the `atmelmegaavr` platform for the ATtiny3226 microcontroller.

---
*PR created automatically by Jules for task [6346108769032475510](https://jules.google.com/task/6346108769032475510) started by @LokiMetaSmith*