### PR TITLE
Add LoRaWAN telemetry support

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -6,6 +6,9 @@ monitor_speed = 115200
 
 build_flags =
     -D ENCODER_DO_NOT_USE_INTERRUPTS
+    -D ARDUINO_LMIC_PROJECT_CONFIG_H_SUPPRESS
+    -D CFG_us915=1
+    -D CFG_sx1276_radio=1
     -Os
     -flto
     -ffunction-sections
@@ -26,3 +29,4 @@ lib_deps =
     adafruit/Adafruit GFX Library
     PaulStoffregen/Encoder
     br3ttb/PID-AutoTune
+    mcci-catena/MCCI LoRaWAN LMIC library

--- a/src/globals.h
+++ b/src/globals.h
@@ -81,9 +81,16 @@ const int analogBatt  = PIN_PD3;
 const int rotary_A_pin = PIN_PD4;
 const int rotary_B_pin = PIN_PD5;
 const int rotary_SW_pin = PIN_PD6;
-const int muteButtonPin = PIN_PA4;
+const int muteButtonPin = PIN_PD7;
 // I2C pins are PA1 (SDA) and PA2 (SCL) - handled by Wire library
 // UART pins are PB2 (TX) and PB3 (RX) - handled by Serial library
+// SPI pins are PA4 (MOSI), PA5 (MISO), PA6 (SCK) - handled by SPI library
+
+// LoRaWAN pins
+const int lora_NSS_pin = PIN_PA7;
+const int lora_RST_pin = PIN_PF0;
+const int lora_DIO0_pin = PIN_PF1;
+const int lora_DIO1_pin = PIN_PC4; // PF2 does not exist on 28-pin. Using PC4.
 
 // Constants (can be defined in header)
 const int battADCMax  =  1023;

--- a/src/lorawan.cpp
+++ b/src/lorawan.cpp
@@ -1,0 +1,147 @@
+#include "lorawan.h"
+
+// This EUI must be in little-endian format, so least-significant-byte
+// first. When copying an EUI from ttnctl output, this means to reverse
+// the bytes. For TTN issued EUIs the last bytes should be 0xD5, 0xB3,
+// 0x70.
+static const u1_t PROGMEM APPEUI[8] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+void os_getArtEui (u1_t* buf) { memcpy_P(buf, APPEUI, 8); }
+
+// This should also be in little endian format, see above.
+static const u1_t PROGMEM DEVEUI[8] = { 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+void os_getDevEui (u1_t* buf) { memcpy_P(buf, DEVEUI, 8); }
+
+// This key should be in big endian format (or, since it is not really a
+// number but a block of memory, endianness does not really apply). In
+// practice, a key taken from the TTN console can be copied as-is.
+static const u1_t PROGMEM APPKEY[16] = { 0x2B, 0x7E, 0x15, 0x16, 0x28, 0xAE, 0xD2, 0xA6, 0xAB, 0xF7, 0x15, 0x88, 0x09, 0xCF, 0x4F, 0x3C };
+void os_getDevKey (u1_t* buf) { memcpy_P(buf, APPKEY, 16); }
+
+static uint8_t mydata[16];
+static osjob_t sendjob;
+const unsigned TX_INTERVAL = 60; // Schedule TX every this many seconds (might become longer due to duty cycle limitations).
+
+// Pin mapping
+const lmic_pinmap lmic_pins = {
+    .nss = lora_NSS_pin,
+    .rxtx = LMIC_UNUSED_PIN,
+    .rst = lora_RST_pin,
+    .dio = {lora_DIO0_pin, lora_DIO1_pin, LMIC_UNUSED_PIN},
+};
+
+void do_send(osjob_t* j) {
+    // Check if there is not a current TX/RX job running
+    if (LMIC.opmode & OP_TXRXPEND) {
+        Serial.println(F("OP_TXRXPEND, not sending"));
+    } else {
+        // Prepare upstream data transmission at the next possible time.
+        // Pack pressure, rpm, battery into mydata
+        uint16_t pres = (uint16_t)ipap_pressure;
+        uint16_t rpm = (uint16_t)fanRPM;
+        uint8_t batt = (uint8_t)batteryState;
+
+        mydata[0] = (pres >> 8) & 0xFF;
+        mydata[1] = pres & 0xFF;
+        mydata[2] = (rpm >> 8) & 0xFF;
+        mydata[3] = rpm & 0xFF;
+        mydata[4] = batt;
+
+        LMIC_setTxData2(1, mydata, 5, 0);
+        Serial.println(F("Packet queued"));
+    }
+}
+
+void onEvent (ev_t ev) {
+    Serial.print(os_getTime());
+    Serial.print(": ");
+    switch(ev) {
+        case EV_SCAN_TIMEOUT:
+            Serial.println(F("EV_SCAN_TIMEOUT"));
+            break;
+        case EV_BEACON_FOUND:
+            Serial.println(F("EV_BEACON_FOUND"));
+            break;
+        case EV_BEACON_MISSED:
+            Serial.println(F("EV_BEACON_MISSED"));
+            break;
+        case EV_BEACON_TRACKED:
+            Serial.println(F("EV_BEACON_TRACKED"));
+            break;
+        case EV_JOINING:
+            Serial.println(F("EV_JOINING"));
+            break;
+        case EV_JOINED:
+            Serial.println(F("EV_JOINED"));
+            // Disable link check validation (automatically enabled
+            // during join, but not supported by TTN at this time).
+            LMIC_setLinkCheckMode(0);
+            break;
+        case EV_JOIN_FAILED:
+            Serial.println(F("EV_JOIN_FAILED"));
+            break;
+        case EV_REJOIN_FAILED:
+            Serial.println(F("EV_REJOIN_FAILED"));
+            break;
+        case EV_TXCOMPLETE:
+            Serial.println(F("EV_TXCOMPLETE (includes waiting for RX windows)"));
+            if (LMIC.txrxFlags & TXRX_ACK)
+              Serial.println(F("Received ack"));
+            if (LMIC.dataLen) {
+              Serial.println(F("Received "));
+              Serial.println(LMIC.dataLen);
+              Serial.println(F(" bytes of payload"));
+            }
+            // Schedule next transmission
+            os_setTimedCallback(&sendjob, os_getTime()+sec2osticks(TX_INTERVAL), do_send);
+            break;
+        case EV_LOST_TSYNC:
+            Serial.println(F("EV_LOST_TSYNC"));
+            break;
+        case EV_RESET:
+            Serial.println(F("EV_RESET"));
+            break;
+        case EV_RXCOMPLETE:
+            // data received in ping slot
+            Serial.println(F("EV_RXCOMPLETE"));
+            break;
+        case EV_LINK_DEAD:
+            Serial.println(F("EV_LINK_DEAD"));
+            break;
+        case EV_LINK_ALIVE:
+            Serial.println(F("EV_LINK_ALIVE"));
+            break;
+        case EV_TXSTART:
+            Serial.println(F("EV_TXSTART"));
+            break;
+        case EV_TXCANCELED:
+            Serial.println(F("EV_TXCANCELED"));
+            break;
+        case EV_RXSTART:
+            /* do not print anything -- it wreaks havoc with timing */
+            break;
+        case EV_JOIN_TXCOMPLETE:
+            Serial.println(F("EV_JOIN_TXCOMPLETE: no JoinAccept"));
+            break;
+        default:
+            Serial.print(F("Unknown event: "));
+            Serial.println((unsigned) ev);
+            break;
+    }
+}
+
+void setupLoRaWAN() {
+    // LMIC init
+    os_init();
+    // Reset the MAC state. Session and pending data transfers will be discarded.
+    LMIC_reset();
+
+    // Allow more clock error to handle inaccuracies in internal oscillator
+    LMIC_setClockError(MAX_CLOCK_ERROR * 1 / 100);
+
+    // Start job (sending automatically starts OTAA too)
+    do_send(&sendjob);
+}
+
+void loopLoRaWAN() {
+    os_runloop_once();
+}

--- a/src/lorawan.h
+++ b/src/lorawan.h
@@ -1,0 +1,12 @@
+#ifndef LORAWAN_H
+#define LORAWAN_H
+
+#include <Arduino.h>
+#include <lmic.h>
+#include <hal/hal.h>
+#include "globals.h"
+
+void setupLoRaWAN();
+void loopLoRaWAN();
+
+#endif // LORAWAN_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,6 +16,7 @@
 #include "user_input.h"
 #include "display.h"
 #include "menu.h"
+#include "lorawan.h"
 
 // --- Global Variable Definitions ---
 // These are declared as 'extern' in globals.h
@@ -109,6 +110,9 @@ void setup() {
   for(int i=0; i<10; i++) {
     pressure_history[i] = 0;
   }
+
+  // Setup LoRaWAN
+  setupLoRaWAN();
 }
 
 // the loop routine runs over and over again forever:
@@ -169,6 +173,9 @@ void loop() {
 
   // Update the OLED display
   updateDisplay();
+
+  // Process LoRaWAN tasks
+  loopLoRaWAN();
 
   // --- Serial Debug Output ---
   Serial.print(" pressure = ");      Serial.print((int)pressure);

--- a/wiring.yml
+++ b/wiring.yml
@@ -36,15 +36,23 @@ connectors:
     type: Power Jack
     pins: [V_BATT, GND]
 
+  Mute_Button:
+    type: Push Button
+    pins: [SIG, GND]
+
   Programmer:
     type: Serial-UPDI Adapter
     pins: [UPDI, TX, RX, GND]
 
+  LoRa_Module:
+    type: RFM95W
+    pins: [VCC, GND, SCK, MISO, MOSI, NSS, DIO0, DIO1, RST]
+
 # Define the connections between the components.
 connections:
   # Power Connections
-  - ["Power_In:V_BATT", "MCU:VCC", "BME280:VCC", "Fan:VCC", "Potentiometer:VCC", "Rotary_Encoder:VCC"]
-  - ["Power_In:GND", "MCU:GND", "BME280:GND", "Fan:GND", "Potentiometer:GND", "LED_Array:GND", "Buzzer:GND", "Rotary_Encoder:GND", "Programmer:GND"]
+  - ["Power_In:V_BATT", "MCU:VCC", "BME280:VCC", "Fan:VCC", "Potentiometer:VCC", "Rotary_Encoder:VCC", "LoRa_Module:VCC"]
+  - ["Power_In:GND", "MCU:GND", "BME280:GND", "Fan:GND", "Potentiometer:GND", "LED_Array:GND", "Buzzer:GND", "Rotary_Encoder:GND", "Programmer:GND", "LoRa_Module:GND", "Mute_Button:GND"]
 
   # I2C Bus
   - ["MCU:PA1", "BME280:SDA"]
@@ -67,12 +75,22 @@ connections:
   - ["MCU:PD0", "Potentiometer:SIG"]
   - ["MCU:PD1", "Power_In:V_BATT", {label: "V_SENSE (via divider)"}]
 
-  # Digital Inputs (Rotary Encoder)
+  # Digital Inputs (Rotary Encoder & Button)
   - ["MCU:PD2", "Rotary_Encoder:CLK"]
   - ["MCU:PD3", "Rotary_Encoder:DT"]
   - ["MCU:PD4", "Rotary_Encoder:SW"]
+  - ["MCU:PD7", "Mute_Button:SIG"]
 
   # Programming and Debug
   - ["MCU:PA0", "Programmer:UPDI"]
   - ["MCU:PB2", "Programmer:TX"]
   - ["MCU:PB3", "Programmer:RX"]
+
+  # LoRaWAN / SPI Connections
+  - ["MCU:PA6", "LoRa_Module:SCK"]
+  - ["MCU:PA5", "LoRa_Module:MISO"]
+  - ["MCU:PA4", "LoRa_Module:MOSI"]
+  - ["MCU:PA7", "LoRa_Module:NSS"]
+  - ["MCU:PF0", "LoRa_Module:RST"]
+  - ["MCU:PF1", "LoRa_Module:DIO0"]
+  - ["MCU:PC4", "LoRa_Module:DIO1"]


### PR DESCRIPTION
This PR introduces LoRaWAN capabilities to the project to allow remote monitoring of the user's status. It utilizes the `mcci-catena/MCCI LoRaWAN LMIC library` with an RFM95W LoRa radio module to transmit telemetry (pressure, RPM, and battery state) over LoRaWAN.

Hardware changes required:
- Added an RFM95W module, connected to the SPI bus.
- Moved `muteButtonPin` from `PA4` (which acts as the SPI MOSI line) to `PD7`.

Software changes:
- Included necessary build flags and the LMIC library dependency in `platformio.ini`.
- Created `lorawan.h` and `lorawan.cpp` to abstract LoRaWAN logic.
- Periodically calls the LMIC stack loop in the main `loop()` function.

---
*PR created automatically by Jules for task [988768801219420597](https://jules.google.com/task/988768801219420597) started by @LokiMetaSmith*