### PR TITLE
feat: Implement Adaptive Thresholds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .pio/
+venv/

--- a/TODO.md
+++ b/TODO.md
@@ -31,9 +31,9 @@ This list tracks potential next steps and improvements for the PAPR firmware pro
     - [x] Integrate a PID autotuning library.
     - [x] Add a serial command to trigger the autotuning process.
     - [x] Automatically save the new PID constants to EEPROM upon completion.
-- [ ] **Adaptive Thresholds:**
-    - [ ] Implement a "learning phase" to establish baseline respiratory rate for alerts.
-    - [ ] Rework breath trigger to "ramp" based on initial user breathing.
+- [x] **Adaptive Thresholds:**
+    - [x] Implement a "learning phase" to establish baseline respiratory rate for alerts.
+    - [x] Rework breath trigger to "ramp" based on initial user breathing.
 - [x] **Filter Lifecycle Management:**
     - [x] Add a `newfilter` command to run calibration and save the baseline impedance to EEPROM.
 - [x] **UI Enhancements:**

--- a/src/alerts.cpp
+++ b/src/alerts.cpp
@@ -44,8 +44,16 @@ void checkAlerts() {
   }
 
   // Respiratory Rate Check
-  if (respiratory_rate > 0) {
-    if (respiratory_rate < 8 || respiratory_rate > 35) {
+  if (respiratory_rate > 0 && !learning_phase_active) {
+    // Determine dynamic thresholds based on baseline (+/- 50%)
+    float min_rr = baseline_respiratory_rate * 0.5;
+    float max_rr = baseline_respiratory_rate * 1.5;
+
+    // Clamp thresholds to absolute safe limits (e.g., min 8, max 35)
+    if (min_rr < 8.0) min_rr = 8.0;
+    if (max_rr > 35.0) max_rr = 35.0;
+
+    if (respiratory_rate < min_rr || respiratory_rate > max_rr) {
       Serial.println(F("ALERT: Abnormal respiratory rate!"));
       condition_found = true;
     }

--- a/src/breath_model.cpp
+++ b/src/breath_model.cpp
@@ -47,12 +47,15 @@ void updateBreathModel(double raw_pressure) {
       currentBreathState = STATE_INHALE;
 
       // Update the running average of the peak slopes
-      // Using a simple moving average with a factor of 0.2 (i.e., last 5 breaths)
+      // During the learning phase, adapt more quickly (factor of 0.5)
+      // Otherwise, use a simple moving average with a factor of 0.2 (i.e., last 5 breaths)
+      float learning_rate = learning_phase_active ? 0.5 : 0.2;
+
       if (peak_inhale_slope > 0) { // Only update if we had a valid peak
-        avg_peak_inhale_slope = (0.8 * avg_peak_inhale_slope) + (0.2 * peak_inhale_slope);
+        avg_peak_inhale_slope = ((1.0 - learning_rate) * avg_peak_inhale_slope) + (learning_rate * peak_inhale_slope);
       }
       if (peak_exhale_slope < 0) { // Only update if we had a valid peak
-        avg_peak_exhale_slope = (0.8 * avg_peak_exhale_slope) + (0.2 * peak_exhale_slope);
+        avg_peak_exhale_slope = ((1.0 - learning_rate) * avg_peak_exhale_slope) + (learning_rate * peak_exhale_slope);
       }
 
       // Reset the peak inhale slope for the new phase
@@ -63,6 +66,25 @@ void updateBreathModel(double raw_pressure) {
       if (last_inhale_time > 0) {
         double interval_s = (double)(now - last_inhale_time) / 1000.0;
         respiratory_rate = 60.0 / interval_s;
+
+        // --- Learning Phase for Adaptive Thresholds ---
+        if (learning_phase_active) {
+          // If we are within the first 60 seconds of learning
+          if (now - learning_phase_start_time < 60000) {
+            learning_rr_sum += respiratory_rate;
+            learning_breath_count++;
+          } else {
+            // Learning phase is over
+            learning_phase_active = false;
+            if (learning_breath_count > 0) {
+              baseline_respiratory_rate = learning_rr_sum / learning_breath_count;
+            } else {
+              baseline_respiratory_rate = 15.0; // Fallback default
+            }
+            Serial.print(F("Learning phase complete. Baseline RR: "));
+            Serial.println(baseline_respiratory_rate);
+          }
+        }
       }
       last_inhale_time = now;
 

--- a/src/globals.h
+++ b/src/globals.h
@@ -60,6 +60,12 @@ extern double avg_peak_exhale_slope;
 extern double baseline_impedance;
 extern double pressure_compensation;
 
+extern bool learning_phase_active;
+extern unsigned long learning_phase_start_time;
+extern float baseline_respiratory_rate;
+extern int learning_breath_count;
+extern float learning_rr_sum;
+
 #include "menu.h" // For MenuState enum
 
 extern String serialCommand;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,6 +50,11 @@ double avg_peak_inhale_slope = 2.0; // Initial default
 double avg_peak_exhale_slope = -2.0; // Initial default
 double baseline_impedance = 0.0;
 double pressure_compensation = 0.0;
+bool learning_phase_active = true;
+unsigned long learning_phase_start_time = 0;
+float baseline_respiratory_rate = 15.0; // Default reasonable value
+int learning_breath_count = 0;
+float learning_rr_sum = 0.0;
 String serialCommand;
 bool apnea_alert_active = false;
 bool alerts_muted = false;
@@ -78,6 +83,7 @@ void setup() {
   // Initialize timers
   pid_last_time = millis();
   last_inhale_time = millis();
+  learning_phase_start_time = millis();
 
   // Set initial pin states
   digitalWrite(led1, HIGH);


### PR DESCRIPTION
Implements the "Adaptive Thresholds" TODO item by introducing a 60-second learning phase at system startup. 
During this phase, it computes a baseline respiratory rate and applies an accelerated Exponential Weighted Moving Average (EWMA) to the breath trigger thresholds for a faster "ramp" based on initial user breathing. 
Alerts dynamically adjust safe bounds based on the baseline (+/- 50%).

---
*PR created automatically by Jules for task [12445392591925097043](https://jules.google.com/task/12445392591925097043) started by @LokiMetaSmith*